### PR TITLE
Add Leaflet map for Great Plains route and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# ATS Great Plains Route
+
+A simple static map showing the route across the Great Plains using [Leaflet](https://leafletjs.com/) and [Leaflet.PolylineDecorator](https://github.com/bbecquet/Leaflet.PolylineDecorator).
+
+## GitHub Pages
+
+1. Push this repository to GitHub.
+2. Open the repository on GitHub and go to **Settings** → **Pages**.
+3. Under **Source**, choose `Deploy from a branch` and select the `main` branch with `/ (root)` folder.
+4. Save. GitHub will build the site and provide a URL like:
+   `https://<username>.github.io/ats-great-plains-route/`
+
+## Development
+
+The site is a single `index.html` file. Open it in a browser to view the map.

--- a/index.html
+++ b/index.html
@@ -1,1 +1,86 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>ATS Great Plains Route</title>
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha512-sA+e2WFqJPKxU9IiiaivGi99ZTSdKCbFf8gDuwZQ+Q0jrISFRCGDpa2BkLomqKgJo0vvVuv5QWFl/dwZ0pQf0A=="
+    crossorigin=""
+  />
+  <style>
+    html, body, #map { height: 100%; margin: 0; }
+    .city-marker {
+      background: #2a9fd6;
+      color: #fff;
+      border-radius: 50%;
+      width: 24px;
+      height: 24px;
+      line-height: 24px;
+      text-align: center;
+      font-weight: bold;
+    }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script
+    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha512-OzHnGoQHe9fFDHBW1ManIeZDV4SSQdlqzTeWY5Avzkdxl3pNGdisz8Iky3Uczdlz7YTlNxP70uQh6Uu1qzPLxA=="
+    crossorigin=""
+  ></script>
+  <script src="https://unpkg.com/leaflet.polylinedecorator@1.7.0/dist/leaflet.polylineDecorator.min.js"></script>
+  <script>
+    // --- 座標配列 ---
+    const cities = [
+      { name: "Dalhart, TX", coords: [36.059305, -102.513519] },
+      { name: "Guymon, OK", coords: [36.682762, -101.481544] },
+      { name: "Garden City, KS", coords: [37.971689, -100.872661] },
+      { name: "Dodge City, KS", coords: [37.752798, -100.017078] },
+      { name: "Hutchinson, KS", coords: [38.060844, -97.929774] },
+      { name: "Wichita, KS", coords: [37.687176, -97.330052] },
+      { name: "Emporia, KS", coords: [38.403903, -96.181662] },
+      { name: "Topeka, KS", coords: [39.055825, -95.689018] },
+      { name: "Kansas City, MO", coords: [39.099724, -94.578331] }
+    ];
 
+    const map = L.map('map');
+
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attribution">CARTO</a>',
+      maxZoom: 19
+    }).addTo(map);
+
+    const routeCoords = cities.map(c => c.coords);
+    const routeLine = L.polyline(routeCoords, { color: '#d95f0e', weight: 4 }).addTo(map);
+    map.fitBounds(routeLine.getBounds());
+
+    // --- マーカー生成 ---
+    cities.forEach((city, index) => {
+      const marker = L.marker(city.coords, {
+        icon: L.divIcon({
+          html: `<div class="city-marker">${index + 1}</div>`,
+          className: ''
+        })
+      }).addTo(map);
+      marker.bindPopup(city.name);
+    });
+
+    // --- 矢印生成 ---
+    L.polylineDecorator(routeLine, {
+      patterns: [
+        {
+          offset: 25,
+          repeat: 50,
+          symbol: L.Symbol.arrowHead({
+            pixelSize: 8,
+            polygon: false,
+            pathOptions: { color: '#d95f0e', weight: 2 }
+          })
+        }
+      ]
+    }).addTo(map);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Build full-screen Leaflet map tracing the Great Plains route with numbered markers and directional arrows
- Document how to publish the static site using GitHub Pages

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden)*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf822dcf48332b5589770a6000b9a